### PR TITLE
feat: use version of provider-project that uses cdktf Github org instead of hashicorp

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,8 +1,8 @@
 {
   "dependencies": [
     {
-      "name": "@cdktf/provider-project",
-      "version": "^0.2.8",
+      "name": "@ansgar/cdktf-provider-project",
+      "version": "0.2.63-cdktf-gh-org",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -282,19 +282,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@ansgar/cdktf-provider-project'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@ansgar/cdktf-provider-project'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@ansgar/cdktf-provider-project'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@ansgar/cdktf-provider-project'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@ansgar/cdktf-provider-project'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { CdktfProviderProject } = require("@cdktf/provider-project");
+const { CdktfProviderProject } = require("@ansgar/cdktf-provider-project");
 const project = new CdktfProviderProject({
   useCustomGithubRunner: true,
   terraformProvider: "hashicorp/hashicups@~> 0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Prebuilt hashicups Provider for Terraform CDK (cdktf)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashicorp/cdktf-provider-hashicups.git"
+    "url": "https://github.com/cdktf/cdktf-provider-hashicups.git"
   },
   "scripts": {
     "build": "npx projen build",
@@ -42,7 +42,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@cdktf/provider-project": "^0.2.8",
+    "@ansgar/cdktf-provider-project": "0.2.63-cdktf-gh-org",
     "@types/node": "^14",
     "cdktf": "^0.12.2",
     "cdktf-cli": "^0.12.2",
@@ -98,7 +98,7 @@
         "packageId": "HashiCorp.Cdktf.Providers.Hashicups"
       },
       "go": {
-        "moduleName": "github.com/hashicorp/cdktf-provider-hashicups-go",
+        "moduleName": "github.com/cdktf/cdktf-provider-hashicups-go",
         "packageName": "hashicups"
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ansgar/cdktf-provider-project@0.2.63-cdktf-gh-org":
+  version "0.2.63-cdktf-gh-org"
+  resolved "https://registry.yarnpkg.com/@ansgar/cdktf-provider-project/-/cdktf-provider-project-0.2.63-cdktf-gh-org.tgz#bcb16532d6465ec2051e4d8143e879ee223dab95"
+  integrity sha512-E4PWJPTRnpFkZj24K2uhcbWBl5XWKx85BAXp3EH1dh8Oay+GUQPdlRkB/dW2qqlGcmH2vplJ44wrPazyePRcaA==
+  dependencies:
+    change-case "^4.1.2"
+    fs-extra "^10.1.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -99,14 +107,6 @@
     fs-extra "^8.1.0"
     is-valid-domain "^0.1.6"
     jsii-srcmak "^0.1.655"
-
-"@cdktf/provider-project@^0.2.8":
-  version "0.2.59"
-  resolved "https://registry.yarnpkg.com/@cdktf/provider-project/-/provider-project-0.2.59.tgz#c8f736fa700350dbf4e66c009d769ef321735955"
-  integrity sha512-GNrcaff9hRRWhSpmspLjssnjsFvN03u8tDazr3tdOkeHAnNNn+7wSuvqABrGpKWwKdeojZTku8aLVVTxQOQZrw==
-  dependencies:
-    change-case "^4.1.2"
-    fs-extra "^10.1.0"
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"


### PR DESCRIPTION
`@ansgar/cdktf-provider-project@0.2.60-cdktf-gh-org` has been manually build and published based on the PR https://github.com/hashicorp/cdktf-provider-project/pull/250
